### PR TITLE
feat(validation questionnaire): create validation for questionnaire level one and two

### DIFF
--- a/components/Questionnaire/One/index.vue
+++ b/components/Questionnaire/One/index.vue
@@ -1,4 +1,3 @@
-## Q1
 <template>
   <div
     :class="{

--- a/components/Questionnaire/One/index.vue
+++ b/components/Questionnaire/One/index.vue
@@ -1,356 +1,341 @@
+## Q1
 <template>
-  <div id="registration" class="registration-questionnaire">
-    <div class="registration--position">
-      <img class="registration__image" src="~/assets/images/FooterBanner.svg" alt="footer banner">
-      <div class="registration__questionnaire">
-        <div v-if="!showModalLevelDesa">
-          <div
-            :class="{
-              'registration__questionnaire-body': true,
-              'registration__questionnaire-modal': showModalInfoVillage,
-            }"
-            @click.self="onCloseModal"
-          >
-            <ModalInfoVillage
-              v-if="showModalInfoVillage"
-              class="relative"
-              @onCloseModal="onCloseModal"
-            />
-            <div
-              v-else
-            >
-              <div class="registration__form" />
-              <div class="registration__form-title">
-                Kuisioner Desa Digital
-              </div>
-              <div class="registration__form-content">
-                <jds-section-message
-                  show
-                  name="info"
-                  variant="info"
-                  :message="infoProgram"
+  <div
+    :class="{
+      'registration__questionnaire-body': true,
+      'registration__questionnaire-modal': showModalInfoVillage,
+    }"
+    @click.self="onCloseModal"
+  >
+    <ModalInfoVillage
+      v-if="showModalInfoVillage"
+      class="relative"
+      @onCloseModal="onCloseModal"
+    />
+    <div
+      v-else
+    >
+      <div class="registration__form" />
+      <div class="registration__form-title">
+        Kuisioner Desa Digital
+      </div>
+      <div class="registration__form-content">
+        <jds-section-message
+          show
+          name="info"
+          variant="info"
+          :message="infoProgram"
+        >
+          <div class="registration__form-info" @click="onClickInfo">
+            Lihat Level Desa Digital
+          </div>
+        </jds-section-message>
+
+        <div class="registration__form-content--container">
+          <p class="mb-3">
+            Apakah desa tempat Bapak/Ibu tinggal dapat diakses oleh kendaraan?
+          </p>
+          <jds-checkbox-group
+            v-model="fasilitas_desa.akses_kendaraan.data"
+            :options="optionsKendaraan"
+            value-key="value"
+            label-key="value"
+          />
+          <div class="grid grid-cols-5 mt-4">
+            <div class="registration__form-col-image">
+              <div
+                :class="{
+                  'registration__form__image': true,
+                  'registration__form__image--attached': files.kendaraan.isAttached
+                }"
+              >
+                <img
+                  v-if="files.kendaraan.source"
+                  class="registration__form__image--attached-uploaded"
+                  width="88"
+                  height="88"
+                  :src="files.kendaraan.source"
+                  alt="Foto Kendaraan"
                 >
-                  <div class="registration__form-info" @click="onClickInfo">
-                    Lihat Level Desa Digital
-                  </div>
-                </jds-section-message>
-
-                <!-- @todo: remove this section container in next feature (id desa search) -->
-                <div class="registration__form-content--container">
-                  <jds-input-text v-model="params.id" placeholder="ID Desa" />
-                </div>
-
-                <div class="registration__form-content--container">
-                  <p class="mb-3">
-                    Apakah desa tempat Bapak/Ibu tinggal dapat diakses oleh kendaraan?
-                  </p>
-                  <jds-checkbox-group
-                    v-model="params.properties.fasilitas_desa.akses_kendaraan.data"
-                    :options="optionsKendaraan"
-                    value-key="value"
-                    label-key="value"
-                  />
-                  <div class="grid grid-cols-5 mt-4">
-                    <div class="registration__form-col-image">
-                      <div
-                        :class="{
-                          'registration__form__image': true,
-                          'registration__form__image--attached': files.kendaraan.isAttached
-                        }"
-                      >
-                        <img
-                          v-if="files.kendaraan.source"
-                          class="registration__form__image--attached-uploaded"
-                          width="88"
-                          height="88"
-                          :src="files.kendaraan.source"
-                          alt="Foto Kendaraan"
-                        >
-                        <img
-                          v-else
-                          class="text-gray-500"
-                          height="22"
-                          width="22"
-                          src="@/assets/icons/IconNoImage.svg"
-                          alt="No Image"
-                        >
-                      </div>
-                    </div>
-                    <div class="registration__form-col-desc">
-                      <div class="registration__form__subtitle">
-                        Unggah foto jalan/akses kendaraan
-                      </div>
-                      <div class="registration__form__placeholder">
-                        File yang didukung adalah .jpg, .jpeg dan .png
-                      </div>
-                      <div class="registration__form__button">
-                        <button class="registration__form__button-btn" type="button" @click="$refs.kendaraan.click()">
-                          Unggah Foto
-                          <jds-icon class="ml-2" size="12px" name="plus-bold" />
-                        </button>
-                        <input
-                          ref="kendaraan"
-                          type="file"
-                          hidden="true"
-                          accept="image/png, image/jpeg, image/svg+xml"
-                          @change="onFileChange('kendaraan')"
-                        >
-                        <div v-if="files.kendaraan.fileImage" class="registration__form__filename">
-                          Filename: {{ files.kendaraan.fileImage.get('file').name }}
-                        </div>
-                        <div v-else-if="files.kendaraan.uploadErrorMessage" class="registration__form__filename-error">
-                          {{ files.kendaraan.uploadErrorMessage }}
-                        </div>
-                        <div v-else class="registration__form__filename">
-                          Belum ada file terpilih.
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-
-                <div class="registration__form-content--container">
-                  <p class="mb-3">
-                    Apakah desa tempat Bapak/Ibu tinggal sudah terdapat suplai listrik?
-                  </p>
-                  <jds-radio-button-group
-                    id="listrik"
-                    v-model="params.properties.fasilitas_desa.suplai_listrik.data"
-                    :items="optionsSuplaiListrik"
-                    value-key="value"
-                    placeholder-key="value"
-                    name="radio-button-group-listrik"
-                  />
-                  <div class="grid grid-cols-5 mt-4">
-                    <div class="registration__form-col-image">
-                      <div
-                        :class="{
-                          'registration__form__image': true,
-                          'registration__form__image--attached': files.listrik.isAttached
-                        }"
-                      >
-                        <img
-                          v-if="files.listrik.source"
-                          class="registration__form__image--attached-uploaded"
-                          width="88"
-                          height="88"
-                          :src="files.listrik.source"
-                          alt="Foto Suplai Listrik"
-                        >
-                        <img
-                          v-else
-                          class="text-gray-500"
-                          height="22"
-                          width="22"
-                          src="@/assets/icons/IconNoImage.svg"
-                          alt="No Image"
-                        >
-                      </div>
-                    </div>
-                    <div class="registration__form-col-desc">
-                      <div class="registration__form__subtitle">
-                        Unggah foto tiang listrik/peralatan elektronik yang sedang menyala
-                      </div>
-                      <div class="registration__form__placeholder">
-                        File yang didukung adalah .jpg, .jpeg dan .png
-                      </div>
-                      <div class="registration__form__button">
-                        <button class="registration__form__button-btn" type="button" @click="$refs.listrik.click()">
-                          Unggah Foto
-                          <jds-icon class="ml-2" size="12px" name="plus-bold" />
-                        </button>
-                        <input
-                          ref="listrik"
-                          type="file"
-                          hidden="true"
-                          accept="image/png, image/jpeg, image/svg+xml"
-                          @change="onFileChange('listrik')"
-                        >
-                        <div v-if="files.listrik.fileImage" class="registration__form__filename">
-                          Filename: {{ files.listrik.fileImage.get('file').name }}
-                        </div>
-                        <div v-else-if="files.listrik.uploadErrorMessage" class="registration__form__filename-error">
-                          {{ files.listrik.uploadErrorMessage }}
-                        </div>
-                        <div v-else class="registration__form__filename">
-                          Belum ada file terpilih.
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-
-                <div class="registration__form-content--container">
-                  <p class="mb-3">
-                    Apakah desa tempat Bapak/Ibu tinggal sudah terdapat jaringan telepon seluler?
-                  </p>
-                  <jds-radio-button-group
-                    id="seluler"
-                    v-model="params.properties.fasilitas_desa.jaringan_telepon.data"
-                    :items="optionsSeluler"
-                    value-key="value"
-                    placeholder-key="value"
-                    name="radio-button-group-seluler"
-                  />
-                  <div class="grid grid-cols-5 mt-4">
-                    <div class="registration__form-col-image">
-                      <div
-                        :class="{
-                          'registration__form__image': true,
-                          'registration__form__image--attached': files.seluler.isAttached
-                        }"
-                      >
-                        <img
-                          v-if="files.seluler.source"
-                          class="registration__form__image--attached-uploaded"
-                          width="88"
-                          height="88"
-                          :src="files.seluler.source"
-                          alt="Foto Seluler"
-                        >
-                        <img
-                          v-else
-                          class="text-gray-500"
-                          height="22"
-                          width="22"
-                          src="@/assets/icons/IconNoImage.svg"
-                          alt="No Image"
-                        >
-                      </div>
-                    </div>
-                    <div class="registration__form-col-desc">
-                      <div class="registration__form__subtitle">
-                        Unggah foto tiang telepon/ screenshoot handphone untuk mengetahui kualitas sinyal
-                      </div>
-                      <div class="registration__form__placeholder">
-                        File yang didukung adalah .jpg, .jpeg dan .png
-                      </div>
-                      <div class="registration__form__button">
-                        <button class="registration__form__button-btn" type="button" @click="$refs.seluler.click()">
-                          Unggah Foto
-                          <jds-icon class="ml-2" size="12px" name="plus-bold" />
-                        </button>
-                        <input
-                          ref="seluler"
-                          type="file"
-                          hidden="true"
-                          accept="image/png, image/jpeg, image/svg+xml"
-                          @change="onFileChange('seluler')"
-                        >
-                        <div v-if="files.seluler.fileImage" class="registration__form__filename">
-                          Filename: {{ files.seluler.fileImage.get('file').name }}
-                        </div>
-                        <div v-else-if="files.seluler.uploadErrorMessage" class="registration__form__filename-error">
-                          {{ files.seluler.uploadErrorMessage }}
-                        </div>
-                        <div v-else class="registration__form__filename">
-                          Belum ada file terpilih.
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <p class="mb-3">
-                    Tuliskan daftar penyedia layanan telekomunikasi yang ada di sekitar anda (Telkomsel/XL/Tri/dan lain-lain)
-                  </p>
-                  <textarea
-                    v-model="params.properties.fasilitas_desa.jaringan_telepon.operator"
-                    class="form-text-area"
-                    name="Daftar layanan telekomunikasi"
-                    placeholder="Masukkan daftar disini"
-                    rows="5"
-                  />
-                </div>
-
-                <div class="registration__form-content--container">
-                  <p class="mb-3">
-                    Apakah desa tempat Bapak/Ibu tinggal sudah terdapat akses internet?
-                  </p>
-                  <jds-radio-button-group
-                    id="internet"
-                    v-model="params.properties.fasilitas_desa.jaringan_internet.data"
-                    :items="optionsInternet"
-                    value-key="value"
-                    placeholder-key="value"
-                    name="radio-button-group-internet"
-                  />
-                  <div class="grid grid-cols-5 mt-4">
-                    <div class="registration__form-col-image">
-                      <div
-                        :class="{
-                          'registration__form__image': true,
-                          'registration__form__image--attached': files.internet.isAttached
-                        }"
-                      >
-                        <img
-                          v-if="files.internet.source"
-                          class="registration__form__image--attached-uploaded"
-                          width="88"
-                          height="88"
-                          :src="files.internet.source"
-                          alt="Foto Jaringan Internet"
-                        >
-                        <img
-                          v-else
-                          class="text-gray-500"
-                          height="22"
-                          width="22"
-                          src="@/assets/icons/IconNoImage.svg"
-                          alt="No Image"
-                        >
-                      </div>
-                    </div>
-                    <div class="registration__form-col-desc">
-                      <div class="registration__form__subtitle">
-                        Unggah foto modem/wifi/screenshoot handphone untuk mengetahui kualitas data (LTE/3G)
-                      </div>
-                      <div class="registration__form__placeholder">
-                        File yang didukung adalah .jpg, .jpeg dan .png
-                      </div>
-                      <div class="registration__form__button">
-                        <button class="registration__form__button-btn" type="button" @click="$refs.internet.click()">
-                          Unggah Foto
-                          <jds-icon class="ml-2" size="12px" name="plus-bold" />
-                        </button>
-                        <input
-                          ref="internet"
-                          type="file"
-                          hidden="true"
-                          accept="image/png, image/jpeg, image/svg+xml"
-                          @change="onFileChange('internet')"
-                        >
-                        <div v-if="files.internet.fileImage" class="registration__form__filename">
-                          Filename: {{ files.internet.fileImage.get('file').name }}
-                        </div>
-                        <div v-else-if="files.internet.uploadErrorMessage" class="registration__form__filename-error">
-                          {{ files.internet.uploadErrorMessage }}
-                        </div>
-                        <div v-else class="registration__form__filename">
-                          Belum ada file terpilih.
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <p class="mb-3">
-                    Tuliskan daftar website atau aplikasi yang sering diakses
-                  </p>
-                  <textarea
-                    v-model="params.properties.fasilitas_desa.jaringan_internet.website"
-                    class="form-text-area"
-                    name="Daftar website / aplikasi"
-                    placeholder="Masukkan daftar disini"
-                    rows="5"
-                  />
-                </div>
+                <img
+                  v-else
+                  class="text-gray-500"
+                  height="22"
+                  width="22"
+                  src="@/assets/icons/IconNoImage.svg"
+                  alt="No Image"
+                >
               </div>
-
-              <div class="registration__submit">
-                <BaseButton class="registration__submit-btn" label="Selanjutnya" @click="onSubmit" />
+            </div>
+            <div class="registration__form-col-desc">
+              <div class="registration__form__subtitle">
+                Unggah foto jalan/akses kendaraan
+              </div>
+              <div class="registration__form__placeholder">
+                File yang didukung adalah .jpg, .jpeg dan .png
+              </div>
+              <div class="registration__form__button">
+                <button class="registration__form__button-btn" type="button" @click="$refs.kendaraan.click()">
+                  Unggah Foto
+                  <jds-icon class="ml-2" size="12px" name="plus-bold" />
+                </button>
+                <input
+                  ref="kendaraan"
+                  type="file"
+                  hidden="true"
+                  accept="image/png, image/jpeg, image/svg+xml"
+                  @change="onFileChange('kendaraan')"
+                >
+                <div v-if="files.kendaraan.fileImage" class="registration__form__filename">
+                  Filename: {{ files.kendaraan.fileImage.get('file').name }}
+                </div>
+                <div v-else-if="files.kendaraan.uploadErrorMessage" class="registration__form__filename-error">
+                  {{ files.kendaraan.uploadErrorMessage }}
+                </div>
+                <div v-else class="registration__form__filename">
+                  Belum ada file terpilih.
+                </div>
               </div>
             </div>
           </div>
         </div>
 
-        <ModalQuestionnaire v-else :chosen-level="params.level" :village-types="villages" />
+        <div class="registration__form-content--container">
+          <p class="mb-3">
+            Apakah desa tempat Bapak/Ibu tinggal sudah terdapat suplai listrik?
+          </p>
+          <jds-radio-button-group
+            id="listrik"
+            v-model="fasilitas_desa.suplai_listrik.data"
+            :items="optionsSuplaiListrik"
+            value-key="value"
+            placeholder-key="value"
+            name="radio-button-group-listrik"
+          />
+          <div class="grid grid-cols-5 mt-4">
+            <div class="registration__form-col-image">
+              <div
+                :class="{
+                  'registration__form__image': true,
+                  'registration__form__image--attached': files.listrik.isAttached
+                }"
+              >
+                <img
+                  v-if="files.listrik.source"
+                  class="registration__form__image--attached-uploaded"
+                  width="88"
+                  height="88"
+                  :src="files.listrik.source"
+                  alt="Foto Suplai Listrik"
+                >
+                <img
+                  v-else
+                  class="text-gray-500"
+                  height="22"
+                  width="22"
+                  src="@/assets/icons/IconNoImage.svg"
+                  alt="No Image"
+                >
+              </div>
+            </div>
+            <div class="registration__form-col-desc">
+              <div class="registration__form__subtitle">
+                Unggah foto tiang listrik/peralatan elektronik yang sedang menyala
+              </div>
+              <div class="registration__form__placeholder">
+                File yang didukung adalah .jpg, .jpeg dan .png
+              </div>
+              <div class="registration__form__button">
+                <button class="registration__form__button-btn" type="button" @click="$refs.listrik.click()">
+                  Unggah Foto
+                  <jds-icon class="ml-2" size="12px" name="plus-bold" />
+                </button>
+                <input
+                  ref="listrik"
+                  type="file"
+                  hidden="true"
+                  accept="image/png, image/jpeg, image/svg+xml"
+                  @change="onFileChange('listrik')"
+                >
+                <div v-if="files.listrik.fileImage" class="registration__form__filename">
+                  Filename: {{ files.listrik.fileImage.get('file').name }}
+                </div>
+                <div v-else-if="files.listrik.uploadErrorMessage" class="registration__form__filename-error">
+                  {{ files.listrik.uploadErrorMessage }}
+                </div>
+                <div v-else class="registration__form__filename">
+                  Belum ada file terpilih.
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="registration__form-content--container">
+          <p class="mb-3">
+            Apakah desa tempat Bapak/Ibu tinggal sudah terdapat jaringan telepon seluler?
+          </p>
+          <jds-radio-button-group
+            id="seluler"
+            v-model="fasilitas_desa.jaringan_telepon.data"
+            :items="optionsSeluler"
+            value-key="value"
+            placeholder-key="value"
+            name="radio-button-group-seluler"
+          />
+          <div class="grid grid-cols-5 mt-4">
+            <div class="registration__form-col-image">
+              <div
+                :class="{
+                  'registration__form__image': true,
+                  'registration__form__image--attached': files.seluler.isAttached
+                }"
+              >
+                <img
+                  v-if="files.seluler.source"
+                  class="registration__form__image--attached-uploaded"
+                  width="88"
+                  height="88"
+                  :src="files.seluler.source"
+                  alt="Foto Seluler"
+                >
+                <img
+                  v-else
+                  class="text-gray-500"
+                  height="22"
+                  width="22"
+                  src="@/assets/icons/IconNoImage.svg"
+                  alt="No Image"
+                >
+              </div>
+            </div>
+            <div class="registration__form-col-desc">
+              <div class="registration__form__subtitle">
+                Unggah foto tiang telepon/ screenshoot handphone untuk mengetahui kualitas sinyal
+              </div>
+              <div class="registration__form__placeholder">
+                File yang didukung adalah .jpg, .jpeg dan .png
+              </div>
+              <div class="registration__form__button">
+                <button class="registration__form__button-btn" type="button" @click="$refs.seluler.click()">
+                  Unggah Foto
+                  <jds-icon class="ml-2" size="12px" name="plus-bold" />
+                </button>
+                <input
+                  ref="seluler"
+                  type="file"
+                  hidden="true"
+                  accept="image/png, image/jpeg, image/svg+xml"
+                  @change="onFileChange('seluler')"
+                >
+                <div v-if="files.seluler.fileImage" class="registration__form__filename">
+                  Filename: {{ files.seluler.fileImage.get('file').name }}
+                </div>
+                <div v-else-if="files.seluler.uploadErrorMessage" class="registration__form__filename-error">
+                  {{ files.seluler.uploadErrorMessage }}
+                </div>
+                <div v-else class="registration__form__filename">
+                  Belum ada file terpilih.
+                </div>
+              </div>
+            </div>
+          </div>
+          <p class="mb-3">
+            Tuliskan daftar penyedia layanan telekomunikasi yang ada di sekitar anda (Telkomsel/XL/Tri/dan lain-lain)
+          </p>
+          <textarea
+            v-model="fasilitas_desa.jaringan_telepon.operator"
+            class="form-text-area"
+            name="Daftar layanan telekomunikasi"
+            placeholder="Masukkan daftar disini"
+            rows="5"
+          />
+        </div>
+
+        <div class="registration__form-content--container">
+          <p class="mb-3">
+            Apakah desa tempat Bapak/Ibu tinggal sudah terdapat akses internet?
+          </p>
+          <jds-radio-button-group
+            id="internet"
+            v-model="fasilitas_desa.jaringan_internet.data"
+            :items="optionsInternet"
+            value-key="value"
+            placeholder-key="value"
+            name="radio-button-group-internet"
+          />
+          <div class="grid grid-cols-5 mt-4">
+            <div class="registration__form-col-image">
+              <div
+                :class="{
+                  'registration__form__image': true,
+                  'registration__form__image--attached': files.internet.isAttached
+                }"
+              >
+                <img
+                  v-if="files.internet.source"
+                  class="registration__form__image--attached-uploaded"
+                  width="88"
+                  height="88"
+                  :src="files.internet.source"
+                  alt="Foto Jaringan Internet"
+                >
+                <img
+                  v-else
+                  class="text-gray-500"
+                  height="22"
+                  width="22"
+                  src="@/assets/icons/IconNoImage.svg"
+                  alt="No Image"
+                >
+              </div>
+            </div>
+            <div class="registration__form-col-desc">
+              <div class="registration__form__subtitle">
+                Unggah foto modem/wifi/screenshoot handphone untuk mengetahui kualitas data (LTE/3G)
+              </div>
+              <div class="registration__form__placeholder">
+                File yang didukung adalah .jpg, .jpeg dan .png
+              </div>
+              <div class="registration__form__button">
+                <button class="registration__form__button-btn" type="button" @click="$refs.internet.click()">
+                  Unggah Foto
+                  <jds-icon class="ml-2" size="12px" name="plus-bold" />
+                </button>
+                <input
+                  ref="internet"
+                  type="file"
+                  hidden="true"
+                  accept="image/png, image/jpeg, image/svg+xml"
+                  @change="onFileChange('internet')"
+                >
+                <div v-if="files.internet.fileImage" class="registration__form__filename">
+                  Filename: {{ files.internet.fileImage.get('file').name }}
+                </div>
+                <div v-else-if="files.internet.uploadErrorMessage" class="registration__form__filename-error">
+                  {{ files.internet.uploadErrorMessage }}
+                </div>
+                <div v-else class="registration__form__filename">
+                  Belum ada file terpilih.
+                </div>
+              </div>
+            </div>
+          </div>
+          <p class="mb-3">
+            Tuliskan daftar website atau aplikasi yang sering diakses
+          </p>
+          <textarea
+            v-model="fasilitas_desa.jaringan_internet.website"
+            class="form-text-area"
+            name="Daftar website / aplikasi"
+            placeholder="Masukkan daftar disini"
+            rows="5"
+          />
+        </div>
+      </div>
+
+      <div class="registration__submit">
+        <BaseButton class="registration__submit-btn" label="Selanjutnya" @click="onSubmit" />
       </div>
     </div>
   </div>
@@ -398,60 +383,53 @@ export default {
           uploadErrorMessage: null
         }
       },
-      params: {
-        id: '32.09.21.2001', // @todo: remove this in next feature (id desa search)
-        level: 1,
-        properties: {
-          fasilitas_desa: {
-            akses_kendaraan: {
-              data: [],
-              photo: {
-                path: null,
-                original_name: null,
-                source: null
-              }
-            },
-            suplai_listrik: {
-              data: '',
-              photo: {
-                path: null,
-                original_name: null,
-                source: null
-              }
-            },
-            jaringan_telepon: {
-              data: '',
-              photo: {
-                path: null,
-                original_name: null,
-                source: null
-              },
-              operator: ''
-            },
-            jaringan_internet: {
-              data: '',
-              photo: {
-                path: null,
-                original_name: null,
-                source: null
-              },
-              website: ''
-            }
+      fasilitas_desa: {
+        akses_kendaraan: {
+          data: [],
+          photo: {
+            path: null,
+            original_name: null,
+            source: null
           }
+        },
+        suplai_listrik: {
+          data: '',
+          photo: {
+            path: null,
+            original_name: null,
+            source: null
+          }
+        },
+        jaringan_telepon: {
+          data: '',
+          photo: {
+            path: null,
+            original_name: null,
+            source: null
+          },
+          operator: ''
+        },
+        jaringan_internet: {
+          data: '',
+          photo: {
+            path: null,
+            original_name: null,
+            source: null
+          },
+          website: ''
         }
       },
       uploadFileSecret: this.$config.apiSecretUpload,
-      showModalLevelDesa: false,
       showModalInfoVillage: false,
       villages
     }
   },
   watch: {
-    'params.properties.fasilitas_desa.jaringan_internet.data' () {
-      if (this.params.properties.fasilitas_desa.jaringan_internet.data === 'Belum ada jaringan internet') {
-        this.params.level = 1
+    'fasilitas_desa.jaringan_internet.data' () {
+      if (this.fasilitas_desa.jaringan_internet.data === 'Belum ada jaringan internet') {
+        this.$emit('onClickLevel', false)
       } else {
-        this.params.level = 2
+        this.$emit('onClickLevel', true)
       }
     }
   },
@@ -509,9 +487,9 @@ export default {
             this.submitFile(this.files.kendaraan.fileImage)
               .then((response) => {
                 const { source, original_name: originalName, path } = response || null
-                this.params.properties.fasilitas_desa.akses_kendaraan.photo.path = path
-                this.params.properties.fasilitas_desa.akses_kendaraan.photo.source = source
-                this.params.properties.fasilitas_desa.akses_kendaraan.photo.original_name = originalName
+                this.fasilitas_desa.akses_kendaraan.photo.path = path
+                this.fasilitas_desa.akses_kendaraan.photo.source = source
+                this.fasilitas_desa.akses_kendaraan.photo.original_name = originalName
               })
               .catch(() => {
                 kendaraan.isAttached = false
@@ -546,9 +524,9 @@ export default {
             this.submitFile(this.files.listrik.fileImage)
               .then((response) => {
                 const { source, original_name: originalName, path } = response || null
-                this.params.properties.fasilitas_desa.suplai_listrik.photo.path = path
-                this.params.properties.fasilitas_desa.suplai_listrik.photo.source = source
-                this.params.properties.fasilitas_desa.suplai_listrik.photo.original_name = originalName
+                this.fasilitas_desa.suplai_listrik.photo.path = path
+                this.fasilitas_desa.suplai_listrik.photo.source = source
+                this.fasilitas_desa.suplai_listrik.photo.original_name = originalName
               })
               .catch(() => {
                 listrik.isAttached = false
@@ -583,9 +561,9 @@ export default {
             this.submitFile(this.files.seluler.fileImage)
               .then((response) => {
                 const { source, original_name: originalName, path } = response || null
-                this.params.properties.fasilitas_desa.jaringan_telepon.photo.path = path
-                this.params.properties.fasilitas_desa.jaringan_telepon.photo.source = source
-                this.params.properties.fasilitas_desa.jaringan_telepon.photo.original_name = originalName
+                this.fasilitas_desa.jaringan_telepon.photo.path = path
+                this.fasilitas_desa.jaringan_telepon.photo.source = source
+                this.fasilitas_desa.jaringan_telepon.photo.original_name = originalName
               })
               .catch(() => {
                 seluler.isAttached = false
@@ -620,9 +598,9 @@ export default {
             this.submitFile(this.files.internet.fileImage)
               .then((response) => {
                 const { source, original_name: originalName, path } = response || null
-                this.params.properties.fasilitas_desa.jaringan_internet.photo.path = path
-                this.params.properties.fasilitas_desa.jaringan_internet.photo.source = source
-                this.params.properties.fasilitas_desa.jaringan_internet.photo.original_name = originalName
+                this.fasilitas_desa.jaringan_internet.photo.path = path
+                this.fasilitas_desa.jaringan_internet.photo.source = source
+                this.fasilitas_desa.jaringan_internet.photo.original_name = originalName
               })
               .catch(() => {
                 internet.isAttached = false
@@ -634,21 +612,8 @@ export default {
         }
       }
     },
-    async onSubmit () {
-      if (this.params.level === 1) {
-        try {
-          await this.$axios.post('/villages/questionnaire', this.params)
-          this.showModalLevelDesa = true
-        } catch (error) {
-          this.$store.dispatch('toast/showToast', {
-            type: 'error',
-            message: 'Data gagal disimpan, periksa kembali data yang diinputkan'
-          })
-        }
-      } else {
-        // @todo: continue to quissionaire two on next pull request
-        this.showModalLevelDesa = false
-      }
+    onSubmit () {
+      this.$emit('onSubmit', this.fasilitas_desa)
     }
   }
 }

--- a/components/Questionnaire/Two/index.vue
+++ b/components/Questionnaire/Two/index.vue
@@ -1,177 +1,166 @@
 <template>
-  <div id="registration" class="registration-questionnaire">
-    <div class="registration--position">
-      <img class="registration__image" src="~/assets/images/FooterBanner.svg" alt="footer banner">
-      <div class="registration__questionnaire">
-        <div v-if="!showModalLevelDesa">
-          <div class="registration__questionnaire-body">
-            <div class="registration__form">
-              <div class="registration__form-title">
-                Kuisioner Desa Digital
+  <div class="registration__questionnaire-body">
+    <div class="registration__form">
+      <div class="registration__form-title">
+        Kuisioner Desa Digital
+      </div>
+      <div class="registration__form-content">
+        <div class="registration__form-content--container">
+          <p class="mb-3">
+            Komunitas apa saja yang saat ini ada di Desa Bapak/Ibu? (Boleh pilih dari satu)
+          </p>
+          <jds-checkbox-group
+            v-model="literasi_digital.komunitas.data"
+            :options="communities"
+            value-key="value"
+            label-key="value"
+          />
+          <div class="grid grid-cols-5 mt-4">
+            <div class="registration__form-col-image">
+              <div
+                :class="{
+                  'registration__form__image': true,
+                  'registration__form__image--attached': files.komunitas.isAttached
+                }"
+              >
+                <img
+                  v-if="files.komunitas.source"
+                  class="registration__form__image--attached-uploaded"
+                  width="88"
+                  height="88"
+                  :src="files.komunitas.source"
+                  alt="Foto Kendaraan"
+                >
+                <img
+                  v-else
+                  class="text-gray-500"
+                  height="22"
+                  width="22"
+                  src="@/assets/icons/IconNoImage.svg"
+                  alt="No Image"
+                >
               </div>
-              <div class="registration__form-content">
-                <div class="registration__form-content--container">
-                  <p class="mb-3">
-                    Komunitas apa saja yang saat ini ada di Desa Bapak/Ibu? (Boleh pilih dari satu)
-                  </p>
-                  <jds-checkbox-group
-                    v-model="params.properties.literasi_digital.komunitas.data"
-                    :options="communities"
-                    value-key="value"
-                    label-key="value"
-                  />
-                  <div class="grid grid-cols-5 mt-4">
-                    <div class="registration__form-col-image">
-                      <div
-                        :class="{
-                          'registration__form__image': true,
-                          'registration__form__image--attached': files.komunitas.isAttached
-                        }"
-                      >
-                        <img
-                          v-if="files.komunitas.source"
-                          class="registration__form__image--attached-uploaded"
-                          width="88"
-                          height="88"
-                          :src="files.komunitas.source"
-                          alt="Foto Kendaraan"
-                        >
-                        <img
-                          v-else
-                          class="text-gray-500"
-                          height="22"
-                          width="22"
-                          src="@/assets/icons/IconNoImage.svg"
-                          alt="No Image"
-                        >
-                      </div>
-                    </div>
-                    <div class="registration__form-col-desc">
-                      <div class="registration__form__subtitle">
-                        Unggah foto pendamping lokal desa/patriot desa/ koumitas yang ada di desa Bapak/Ibu
-                      </div>
-                      <div class="registration__form__placeholder">
-                        File yang didukung adalah .jpg, .jpeg dan .png
-                      </div>
-                      <div class="registration__form__button">
-                        <button class="registration__form__button-btn" type="button" @click="$refs.komunitas.click()">
-                          Unggah Foto
-                          <jds-icon class="ml-2" size="12px" name="plus-bold" />
-                        </button>
-                        <input
-                          ref="komunitas"
-                          type="file"
-                          hidden="true"
-                          accept="image/png, image/jpeg, image/svg+xml"
-                          @change="onFileChange('komunitas')"
-                        >
-                        <div v-if="files.komunitas.fileImage" class="registration__form__filename">
-                          Filename: {{ files.komunitas.fileImage.get('file').name }}
-                        </div>
-                        <div v-else-if="files.komunitas.uploadErrorMessage" class="registration__form__filename-error">
-                          {{ files.komunitas.uploadErrorMessage }}
-                        </div>
-                        <div v-else class="registration__form__filename">
-                          Belum ada file terpilih.
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-
-                <div class="registration__form-content--container">
-                  <p class="mb-3">
-                    Apakah komunitas tersebut pernah mengadakan program atau pelatihan tentang teknologi digital?
-                  </p>
-                  <jds-radio-button-group
-                    id="pelatihan"
-                    v-model="params.properties.literasi_digital.pelatihan.data"
-                    :items="training"
-                    value-key="value"
-                    placeholder-key="value"
-                    name="radio-button-group-pelatihan"
-                  />
-                </div>
-
-                <div class="registration__form-content--container">
-                  <p class="mb-3">
-                    Pelatihan apa saja yang pernah diberikan?
-                  </p>
-                  <textarea
-                    v-model="params.properties.literasi_digital.pelatihan.pelatihan"
-                    class="form-text-area"
-                    name="Pelatihan"
-                    placeholder="Masukkan pelatihan disini"
-                    rows="5"
-                  />
-                  <div class="grid grid-cols-5 mt-4">
-                    <div class="registration__form-col-image">
-                      <div
-                        :class="{
-                          'registration__form__image': true,
-                          'registration__form__image--attached': files.pelatihan.isAttached
-                        }"
-                      >
-                        <img
-                          v-if="files.pelatihan.source"
-                          class="registration__form__image--attached-uploaded"
-                          width="88"
-                          height="88"
-                          :src="files.pelatihan.source"
-                          alt="Foto pelatihan"
-                        >
-                        <img
-                          v-else
-                          class="text-gray-500"
-                          height="22"
-                          width="22"
-                          src="@/assets/icons/IconNoImage.svg"
-                          alt="No Image"
-                        >
-                      </div>
-                    </div>
-                    <div class="registration__form-col-desc">
-                      <div class="registration__form__subtitle">
-                        Unggah foto kegiatan pelatihan yang pernah dilakukan
-                      </div>
-                      <div class="registration__form__placeholder">
-                        File yang didukung adalah .jpg, .jpeg dan .png
-                      </div>
-                      <div class="registration__form__button">
-                        <button class="registration__form__button-btn" type="button" @click="$refs.pelatihan.click()">
-                          Unggah Foto
-                          <jds-icon class="ml-2" size="12px" name="plus-bold" />
-                        </button>
-                        <input
-                          ref="pelatihan"
-                          type="file"
-                          hidden="true"
-                          accept="image/png, image/jpeg, image/svg+xml"
-                          @change="onFileChange('pelatihan')"
-                        >
-                        <div v-if="files.pelatihan.fileImage" class="registration__form__filename">
-                          Filename: {{ files.pelatihan.fileImage.get('file').name }}
-                        </div>
-                        <div v-else-if="files.pelatihan.uploadErrorMessage" class="registration__form__filename-error">
-                          {{ files.pelatihan.uploadErrorMessage }}
-                        </div>
-                        <div v-else class="registration__form__filename">
-                          Belum ada file terpilih.
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
+            </div>
+            <div class="registration__form-col-desc">
+              <div class="registration__form__subtitle">
+                Unggah foto pendamping lokal desa/patriot desa/ koumitas yang ada di desa Bapak/Ibu
               </div>
-              <div class="registration__submit">
-                <BaseButton class="registration__submit-btn" variant="secondary" label="Kembali" @click="onPreviousPage" />
-                <BaseButton class="registration__submit-btn" label="Selanjutnya" @click="onSubmit" />
+              <div class="registration__form__placeholder">
+                File yang didukung adalah .jpg, .jpeg dan .png
+              </div>
+              <div class="registration__form__button">
+                <button class="registration__form__button-btn" type="button" @click="$refs.komunitas.click()">
+                  Unggah Foto
+                  <jds-icon class="ml-2" size="12px" name="plus-bold" />
+                </button>
+                <input
+                  ref="komunitas"
+                  type="file"
+                  hidden="true"
+                  accept="image/png, image/jpeg, image/svg+xml"
+                  @change="onFileChange('komunitas')"
+                >
+                <div v-if="files.komunitas.fileImage" class="registration__form__filename">
+                  Filename: {{ files.komunitas.fileImage.get('file').name }}
+                </div>
+                <div v-else-if="files.komunitas.uploadErrorMessage" class="registration__form__filename-error">
+                  {{ files.komunitas.uploadErrorMessage }}
+                </div>
+                <div v-else class="registration__form__filename">
+                  Belum ada file terpilih.
+                </div>
               </div>
             </div>
           </div>
         </div>
 
-        <ModalQuestionnaire v-else :chosen-level="params.level" :village-types="villages" />
+        <div class="registration__form-content--container">
+          <p class="mb-3">
+            Apakah komunitas tersebut pernah mengadakan program atau pelatihan tentang teknologi digital?
+          </p>
+          <jds-radio-button-group
+            id="pelatihan"
+            v-model="literasi_digital.pelatihan.data"
+            :items="training"
+            value-key="value"
+            placeholder-key="value"
+            name="radio-button-group-pelatihan"
+          />
+        </div>
+
+        <div class="registration__form-content--container">
+          <p class="mb-3">
+            Pelatihan apa saja yang pernah diberikan?
+          </p>
+          <textarea
+            v-model="literasi_digital.pelatihan.pelatihan"
+            class="form-text-area"
+            name="Pelatihan"
+            placeholder="Masukkan pelatihan disini"
+            rows="5"
+          />
+          <div class="grid grid-cols-5 mt-4">
+            <div class="registration__form-col-image">
+              <div
+                :class="{
+                  'registration__form__image': true,
+                  'registration__form__image--attached': files.pelatihan.isAttached
+                }"
+              >
+                <img
+                  v-if="files.pelatihan.source"
+                  class="registration__form__image--attached-uploaded"
+                  width="88"
+                  height="88"
+                  :src="files.pelatihan.source"
+                  alt="Foto pelatihan"
+                >
+                <img
+                  v-else
+                  class="text-gray-500"
+                  height="22"
+                  width="22"
+                  src="@/assets/icons/IconNoImage.svg"
+                  alt="No Image"
+                >
+              </div>
+            </div>
+            <div class="registration__form-col-desc">
+              <div class="registration__form__subtitle">
+                Unggah foto kegiatan pelatihan yang pernah dilakukan
+              </div>
+              <div class="registration__form__placeholder">
+                File yang didukung adalah .jpg, .jpeg dan .png
+              </div>
+              <div class="registration__form__button">
+                <button class="registration__form__button-btn" type="button" @click="$refs.pelatihan.click()">
+                  Unggah Foto
+                  <jds-icon class="ml-2" size="12px" name="plus-bold" />
+                </button>
+                <input
+                  ref="pelatihan"
+                  type="file"
+                  hidden="true"
+                  accept="image/png, image/jpeg, image/svg+xml"
+                  @change="onFileChange('pelatihan')"
+                >
+                <div v-if="files.pelatihan.fileImage" class="registration__form__filename">
+                  Filename: {{ files.pelatihan.fileImage.get('file').name }}
+                </div>
+                <div v-else-if="files.pelatihan.uploadErrorMessage" class="registration__form__filename-error">
+                  {{ files.pelatihan.uploadErrorMessage }}
+                </div>
+                <div v-else class="registration__form__filename">
+                  Belum ada file terpilih.
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="registration__submit">
+        <BaseButton class="registration__submit-btn" variant="secondary" label="Kembali" @click="onPrev" />
+        <BaseButton class="registration__submit-btn" label="Selanjutnya" @click="onSubmit" />
       </div>
     </div>
   </div>
@@ -202,29 +191,23 @@ export default {
           uploadErrorMessage: null
         }
       },
-      params: {
-        id: '32.09.21.2001', // @todo: remove this in next feature (id desa search)
-        level: 2,
-        properties: {
-          literasi_digital: {
-            komunitas: {
-              data: [],
-              photo: {
-                path: null,
-                original_name: null,
-                source: null
-              }
-            },
-            pelatihan: {
-              data: '',
-              photo: {
-                path: null,
-                original_name: null,
-                source: null
-              },
-              pelatihan: ''
-            }
+      literasi_digital: {
+        komunitas: {
+          data: [],
+          photo: {
+            path: null,
+            original_name: null,
+            source: null
           }
+        },
+        pelatihan: {
+          data: '',
+          photo: {
+            path: null,
+            original_name: null,
+            source: null
+          },
+          pelatihan: ''
         }
       },
       uploadFileSecret: this.$config.apiSecretUpload,
@@ -234,11 +217,11 @@ export default {
     }
   },
   watch: {
-    'params.properties.literasi_digital.pelatihan.data' () {
-      if (this.params.properties.literasi_digital.pelatihan.data === 'Belum pernah') {
-        this.params.level = 2
+    'literasi_digital.pelatihan.data' () {
+      if (this.literasi_digital.pelatihan.data === 'Belum pernah') {
+        this.$emit('onClickLevel', false)
       } else {
-        this.params.level = 3
+        this.$emit('onClickLevel', true)
       }
     }
   },
@@ -290,9 +273,9 @@ export default {
             this.submitFile(this.files.komunitas.fileImage)
               .then((response) => {
                 const { source, original_name: originalName, path } = response || null
-                this.params.properties.literasi_digital.komunitas.photo.path = path
-                this.params.properties.literasi_digital.komunitas.photo.source = source
-                this.params.properties.literasi_digital.komunitas.photo.original_name = originalName
+                this.literasi_digital.komunitas.photo.path = path
+                this.literasi_digital.komunitas.photo.source = source
+                this.literasi_digital.komunitas.photo.original_name = originalName
               })
               .catch(() => {
                 komunitas.isAttached = false
@@ -327,9 +310,9 @@ export default {
             this.submitFile(this.files.pelatihan.fileImage)
               .then((response) => {
                 const { source, original_name: originalName, path } = response || null
-                this.params.properties.literasi_digital.pelatihan.photo.path = path
-                this.params.properties.literasi_digital.pelatihan.photo.source = source
-                this.params.properties.literasi_digital.pelatihan.photo.original_name = originalName
+                this.literasi_digital.pelatihan.photo.path = path
+                this.literasi_digital.pelatihan.photo.source = source
+                this.literasi_digital.pelatihan.photo.original_name = originalName
               })
               .catch(() => {
                 pelatihan.isAttached = false
@@ -342,16 +325,10 @@ export default {
       }
     },
     onSubmit () {
-      if (this.params.level === 2) {
-        // @todo: continue to create validation for questionnaire three
-        this.showModalLevelDesa = true
-      } else {
-        // @todo: continue to questionnaire three on next pull request
-        this.showModalLevelDesa = false
-      }
+      this.$emit('onSubmit', this.literasi_digital)
     },
-    onPreviousPage () {
-      // @todo: create method to show previous
+    onPrev () {
+      this.$emit('onPrev')
     }
   }
 }

--- a/components/Questionnaire/index.vue
+++ b/components/Questionnaire/index.vue
@@ -1,0 +1,184 @@
+<template>
+  <div id="registration" class="registration-questionnaire">
+    <div class="registration--position">
+      <img class="registration__image" src="~/assets/images/FooterBanner.svg" alt="footer banner">
+      <div class="registration__questionnaire">
+        <div v-if="!showModalLevelDesa">
+          <QuestionnaireOne v-show="showLevelOne" @onClickLevel="validationQuestionnaireOne" @onSubmit="onNextLevelOne" />
+          <QuestionnaireTwo v-show="showLevelTwo" @onClickLevel="validationQuestionnaireTwo" @onPrev="onPrev" @onSubmit="onNextLevelTwo" />
+          <QuestionnaireThree v-show="showLevelThree" />
+        </div>
+        <ModalQuestionnaire v-else :chosen-level="params.level" :village-types="villages" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import {
+  villages
+} from '@/constants/questionnaire.js'
+export default {
+  data () {
+    return {
+      params: {
+        id: '32.09.21.2001', // @todo: remove this in next feature (id desa search)
+        level: 1,
+        properties: {
+          fasilitas_desa: {
+            akses_kendaraan: {
+              data: [],
+              photo: {
+                path: null,
+                original_name: null,
+                source: null
+              }
+            },
+            suplai_listrik: {
+              data: '',
+              photo: {
+                path: null,
+                original_name: null,
+                source: null
+              }
+            },
+            jaringan_telepon: {
+              data: '',
+              photo: {
+                path: null,
+                original_name: null,
+                source: null
+              },
+              operator: ''
+            },
+            jaringan_internet: {
+              data: '',
+              photo: {
+                path: null,
+                original_name: null,
+                source: null
+              },
+              website: ''
+            }
+          },
+          literasi_digital: {
+            komunitas: {
+              data: [],
+              photo: {
+                path: null,
+                original_name: null,
+                source: null
+              }
+            },
+            pelatihan: {
+              data: '',
+              photo: {
+                path: null,
+                original_name: null,
+                source: null
+              },
+              pelatihan: ''
+            }
+          },
+          tentang_bumdes: {
+            sosial_media: {
+              data: [],
+              photo: {
+                path: null,
+                original_name: null,
+                source: null
+              }
+            },
+            bumdes: {
+              data: '',
+              photo: {
+                path: null,
+                original_name: null,
+                source: null
+              },
+              bumdes: ''
+            },
+            komoditas: {
+              data: '',
+              photo: {
+                path: null,
+                original_name: null,
+                source: null
+              }
+            }
+          },
+          potensi_desa: {
+            data: '',
+            potensi_dapat_dikembangkan: '',
+            photo: {
+              path: null,
+              original_name: null,
+              source: null
+            }
+          }
+        }
+      },
+      isLevelOne: true,
+      isLevelTwo: false,
+      isLevelThree: false,
+      showLevelOne: true,
+      showLevelTwo: false,
+      showLevelThree: false,
+      showModalLevelDesa: false,
+      villages
+    }
+  },
+  methods: {
+    validationQuestionnaireOne (value) {
+      this.isLevelTwo = value
+    },
+    validationQuestionnaireTwo (value) {
+      this.isLevelThree = value
+    },
+    onNextLevelOne (value) {
+      this.params.properties.fasilitas_desa = value
+      if (this.isLevelTwo) {
+        this.showLevelTwo = true
+        this.showLevelOne = false
+        this.params.level = 2
+      } else {
+        this.showModalLevelDesa = true
+        this.params.level = 1
+        this.onSubmit()
+      }
+    },
+    onNextLevelTwo (value) {
+      this.params.properties.literasi_digital = value
+      if (this.isLevelThree) {
+        this.showLevelThree = true
+        this.showLevelTwo = false
+        this.params.level = 3
+      } else {
+        this.showModalLevelDesa = true
+        this.params.level = 2
+        this.onSubmit()
+      }
+    },
+    onPrev () {
+      if (this.isLevelTwo) {
+        this.showLevelTwo = false
+        this.showLevelOne = true
+      }
+    },
+    async onSubmit () {
+      try {
+        await this.$axios.post('/villages/questionnaire', this.params)
+      } catch (error) {
+        this.$store.dispatch('toast/showToast', {
+          type: 'error',
+          message: 'Data gagal disimpan, periksa kembali data yang diinputkan'
+        })
+      }
+    }
+  }
+}
+</script>
+
+<style lang="postcss">
+@import './Questionnaire.pcss';
+</style>

--- a/components/Questionnaire/index.vue
+++ b/components/Questionnaire/index.vue
@@ -142,7 +142,6 @@ export default {
         this.showLevelOne = false
         this.params.level = 2
       } else {
-        this.showModalLevelDesa = true
         this.params.level = 1
         this.onSubmit()
       }
@@ -154,7 +153,6 @@ export default {
         this.showLevelTwo = false
         this.params.level = 3
       } else {
-        this.showModalLevelDesa = true
         this.params.level = 2
         this.onSubmit()
       }
@@ -168,6 +166,7 @@ export default {
     async onSubmit () {
       try {
         await this.$axios.post('/villages/questionnaire', this.params)
+        this.showModalLevelDesa = true
       } catch (error) {
         this.$store.dispatch('toast/showToast', {
           type: 'error',

--- a/pages/registration.vue
+++ b/pages/registration.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <RegistrationMitra v-if="opsiRegistrasi === 'mitra'" />
-    <QuestionnaireOne v-if="opsiRegistrasi === 'desa'" />
+    <Questionnaire v-if="opsiRegistrasi === 'desa'" />
     <BaseToast />
   </div>
 </template>


### PR DESCRIPTION
## Changes

1. Create `index.vue` in the Questionnaire component  and remove images in `Questionnaire one` and `Questionnaire two` components
2. Add validation function to decide 'desa digital' categories

## Preview

1. Validation Questionnaire level one 
![quest-1](https://user-images.githubusercontent.com/79241754/164617057-9bf6f7e8-ec8c-4138-8db7-febaae93edec.gif)

2. Validation Questionnaire level two
![quest-2](https://user-images.githubusercontent.com/79241754/164617138-32cfe9e1-d2d5-4fb3-9601-dcd4cffe4cf7.gif)

## Evidence
title: feat(validation questionnaire): create validation for questionnaire level one and two
project: Desa Digital
participants: @doohanas @yoslie @Ibwedagama @bangunbagustapa @maulanayuseph @agunghide 