### PR TITLE
refactor: fix typo copywriting in questionnaire level two

### DIFF
--- a/components/Questionnaire/Category/index.vue
+++ b/components/Questionnaire/Category/index.vue
@@ -29,17 +29,20 @@
       </div>
     </div>
     <div class="category__action">
-      <BaseButton
-        class="category__action-signup"
-        label="Daftar Sekarang"
-        @click="onSubmitCategory"
-      />
-      <nuxt-link
-        to="/"
-        class="category__action-cancel"
-      >
-        Nanti Saja
-      </nuxt-link>
+      <div class="category__action-signup">
+        <BaseButton
+          class="w-[290px]"
+          label="Daftar Sekarang"
+          @click="onSubmitCategory"
+        />
+      </div>
+      <div class="category__action-cancel">
+        <nuxt-link
+          to="/"
+        >
+          Nanti Saja
+        </nuxt-link>
+      </div>
     </div>
   </div>
 </template>
@@ -127,7 +130,7 @@ export default {
     @apply text-center;
 
     &-signup {
-      @apply w-full mb-4;
+      @apply mb-4;
     }
 
     &-cancel {

--- a/components/Questionnaire/Category/index.vue
+++ b/components/Questionnaire/Category/index.vue
@@ -93,8 +93,8 @@ export default {
 
 <style lang="postcss" scoped>
 .category {
-  @apply grid grid-rows-1 p-4
-  sm:(p-8 bg-white w-[680px] h-[486px] rounded-2xl);
+  @apply grid grid-rows-1 p-4 mt-20
+  sm:(my-[70px] p-8 bg-white w-[680px] h-[486px] rounded-2xl);
 
   &__title > h1 {
     @apply font-roboto font-bold text-[16px] leading-[22px] text-gray-800 pb-4

--- a/components/Questionnaire/Two/index.vue
+++ b/components/Questionnaire/Two/index.vue
@@ -58,7 +58,7 @@
             </div>
             <div class="registration__form-col-desc">
               <div class="registration__form__subtitle">
-                Unggah foto pendamping lokal desa/patriot desa/ komunitas yang ada di desa Bapak/Ibu
+                Unggah foto pendamping lokal desa/patriot desa/komunitas yang ada di desa Bapak/Ibu
               </div>
               <div class="registration__form__placeholder">
                 File yang didukung adalah .jpg, .jpeg dan .png

--- a/components/Questionnaire/Two/index.vue
+++ b/components/Questionnaire/Two/index.vue
@@ -58,7 +58,7 @@
             </div>
             <div class="registration__form-col-desc">
               <div class="registration__form__subtitle">
-                Unggah foto pendamping lokal desa/patriot desa/ koumitas yang ada di desa Bapak/Ibu
+                Unggah foto pendamping lokal desa/patriot desa/ komunitas yang ada di desa Bapak/Ibu
               </div>
               <div class="registration__form__placeholder">
                 File yang didukung adalah .jpg, .jpeg dan .png


### PR DESCRIPTION
## Changes

- fix typo copywriting in `questionnaire level two`
- fix the width button `daftar sekarang` in `questionnaire category`

## Preview

1. fix typo copywriting in `questionnaire level two`
![image](https://user-images.githubusercontent.com/79241754/168023106-be403f84-9f37-48c6-8bc5-471258d83378.png)

2. fix the width button `daftar sekarang` in `questionnaire category`
![image](https://user-images.githubusercontent.com/79241754/168023167-ba03ff96-1257-43c5-a311-9bdff737af5b.png)

## Evidence
title: refactor: fix typo copywriting in questionnaire level two
project: Desa Digital
participants: @doohanas @yoslie @maulanayuseph @naufalihsank @agunghide 