### PR TITLE
feat (questionnaire-two): add validation to disabled next button if he radio button and checkbox fields are empty

### DIFF
--- a/components/Questionnaire/Two/index.vue
+++ b/components/Questionnaire/Two/index.vue
@@ -175,7 +175,7 @@
       </div>
       <div class="registration__submit">
         <BaseButton class="registration__submit-btn" variant="secondary" label="Kembali" @click="onPrev" />
-        <BaseButton class="registration__submit-btn" label="Selanjutnya" @click="onSubmit" />
+        <BaseButton class="registration__submit-btn" :variant="buttonQuestionnaireTwoVariant" :disabled="!isValidatedQuestionnaireTwo" label="Selanjutnya" @click="onSubmit" />
       </div>
     </div>
   </div>
@@ -231,6 +231,21 @@ export default {
       villages,
       isShowTrainingImage: false,
       isShowCommunityImage: false
+    }
+  },
+  computed: {
+    isValidatedQuestionnaireTwo () {
+      const isCommunityValidated = this.literasi_digital.komunitas.data.length !== 0
+      const isTraningValidated = this.literasi_digital.pelatihan.data !== null
+
+      return (isCommunityValidated && isTraningValidated)
+    },
+    buttonQuestionnaireTwoVariant () {
+      if (this.isValidatedQuestionnaireTwo) {
+        return 'primary'
+      } else {
+        return 'disabled'
+      }
     }
   },
   watch: {


### PR DESCRIPTION
## Changes

- Add validation to disabled `selanjutnya` button if the the radio button and checkbox fields are empty

## Preview

1. Add validation to disabled `selanjutnya` button if the radio button and checkbox fields are empty
![update-quest-2-val](https://user-images.githubusercontent.com/79241754/169194179-b6b92bef-7b12-49bc-8f9d-1d9fa723fd78.gif)

## Evidence
title: feat (questionnaire-two): add validation to disabled next button if the radio button and checkbox fields are empty
project: Desa Digital
participants: @doohanas @maruf12 @Ibwedagama @agunghide @bangunbagustapa @naufalihsank @yoslie @maulanayuseph 