### PR TITLE
refactor (questionnaire): fix height content in questionnaire for responsive

### DIFF
--- a/components/Questionnaire/Category/index.vue
+++ b/components/Questionnaire/Category/index.vue
@@ -93,17 +93,17 @@ export default {
 
 <style lang="postcss" scoped>
 .category {
-  @apply grid grid-rows-1 p-4 mt-20
-  sm:(my-[70px] p-8 bg-white w-[680px] h-[486px] rounded-2xl);
+  @apply grid grid-rows-1 p-4
+  md:(p-8 mt-6 bg-white w-[680px] h-[476px] rounded-2xl);
 
   &__title > h1 {
     @apply font-roboto font-bold text-[16px] leading-[22px] text-gray-800 pb-4
-    sm:(leading-[26px] pb-5);
+    md:(leading-[26px] pb-5);
   }
 
   &__content {
     @apply border border-green-700 rounded-xl text-center mb-4
-    sm:(text-left mb-5 grid grid-cols-2);
+    md:(text-left mb-5 grid grid-cols-2);
 
     &-text {
       @apply mx-[43.5px] sm:(ml-6 mr-0);

--- a/components/Questionnaire/Notification/index.vue
+++ b/components/Questionnaire/Notification/index.vue
@@ -172,8 +172,10 @@ export default {
 
 <style lang='postcss' scoped>
 .notification {
-  @apply my-17.25 grid grid-rows-1 p-4
-  sm:(my-[30px] bg-white p-8 mx-auto bg-white w-[680px] max-h-[640px] rounded-2xl);
+  @apply grid grid-rows-[1/2fr,1fr] p-4
+  sm:(bg-white px-8 mx-auto bg-white w-[680px] rounded-2xl)
+  md:(p-8 max-h-[calc(100vh-100px)])
+  lg:(max-h-[calc(100vh-170px)]);
 
    &__title > h1 {
     @apply font-roboto font-bold text-[16px] leading-[22px] text-gray-800 mb-4
@@ -188,7 +190,8 @@ export default {
     }
 
     &--position {
-      @apply my-auto;
+      @apply my-auto
+      md:(max-h-[calc(100vh-300px)] overflow-y-auto);
     }
 
     &-image {
@@ -202,7 +205,7 @@ export default {
 
     &-message {
       @apply text-center font-sans font-normal text-[14px] leading-[20px] text-gray-800 pb-4
-      sm:(leading-[23px] max-w-[439px]);
+      md:(leading-[23px] max-w-[439px]);
 
       &--bold {
         @apply text-green-700 font-bold;

--- a/components/Questionnaire/Questionnaire.pcss
+++ b/components/Questionnaire/Questionnaire.pcss
@@ -9,7 +9,7 @@
   }
 
   &__questionnaire {
-    @apply relative w-full mt-16 sm:(flex justify-center) md:(justify-center items-center my-auto pt-8);
+    @apply relative w-full mt-16 sm:(flex justify-center) md:(items-center my-auto pt-8);
 
     &-body {
       @apply h-full bg-white p-4 md:(p-8 mx-auto w-[680px] h-auto relative rounded-md);

--- a/components/Questionnaire/Questionnaire.pcss
+++ b/components/Questionnaire/Questionnaire.pcss
@@ -9,7 +9,7 @@
   }
 
   &__questionnaire {
-    @apply relative w-full mt-16 flex justify-center md:(items-center my-auto pt-8);
+    @apply relative w-full mt-16 sm:(flex justify-center) md:(justify-center items-center my-auto pt-8);
 
     &-body {
       @apply h-full bg-white p-4 md:(p-8 mx-auto w-[680px] h-auto relative rounded-md);

--- a/components/Questionnaire/index.vue
+++ b/components/Questionnaire/index.vue
@@ -3,7 +3,8 @@
     <div class="registration--position">
       <img class="registration__image" src="~/assets/images/FooterBanner.svg" alt="footer banner">
       <div class="registration__questionnaire">
-        <div v-if="!isConfirmed">
+        <QuestionnaireNotification :level="4" :potency-villages="params.properties.potensi_desa.data" />
+        <!-- <div v-if="!isConfirmed">
           <QuestionnaireConfirmation @onSubmit="confirmVillage" />
         </div>
         <div v-if="!showModalLevelDesa && isConfirmed">
@@ -14,7 +15,7 @@
         <div v-if="showModalLevelDesa && isConfirmed">
           <QuestionnaireCategory v-show="showCategory" :chosen-level="params.level" :village-types="villages" @onSubmit="onSubmit" />
           <QuestionnaireNotification v-show="showNotification" :level="params.level" :potency-villages="params.properties.potensi_desa.data" />
-        </div>
+        </div> -->
       </div>
     </div>
   </div>
@@ -132,7 +133,7 @@ export default {
             logistik: null
           },
           potensi_desa: {
-            data: [],
+            data: ['Pertanian', 'Perikanan'],
             potensi_dapat_dikembangkan: null,
             photo: {
               path: null,

--- a/components/Questionnaire/index.vue
+++ b/components/Questionnaire/index.vue
@@ -3,8 +3,7 @@
     <div class="registration--position">
       <img class="registration__image" src="~/assets/images/FooterBanner.svg" alt="footer banner">
       <div class="registration__questionnaire">
-        <QuestionnaireNotification :level="4" :potency-villages="params.properties.potensi_desa.data" />
-        <!-- <div v-if="!isConfirmed">
+        <div v-if="!isConfirmed">
           <QuestionnaireConfirmation @onSubmit="confirmVillage" />
         </div>
         <div v-if="!showModalLevelDesa && isConfirmed">
@@ -15,7 +14,7 @@
         <div v-if="showModalLevelDesa && isConfirmed">
           <QuestionnaireCategory v-show="showCategory" :chosen-level="params.level" :village-types="villages" @onSubmit="onSubmit" />
           <QuestionnaireNotification v-show="showNotification" :level="params.level" :potency-villages="params.properties.potensi_desa.data" />
-        </div> -->
+        </div>
       </div>
     </div>
   </div>
@@ -133,7 +132,7 @@ export default {
             logistik: null
           },
           potensi_desa: {
-            data: ['Pertanian', 'Perikanan'],
+            data: [],
             potensi_dapat_dikembangkan: null,
             photo: {
               path: null,


### PR DESCRIPTION
## Changes

- Fix height content in questionnaire  `notification` and `category ` for responsive
- Add a new `sm` breakpoint for the style questionnaire component

## Preview

1. Fix height content in questionnaire  `notification`
     - Before
     ![Screenshot 2022-05-21 130352](https://user-images.githubusercontent.com/79241754/169638402-178036b8-ca25-403f-929e-1feb0b5fb2e6.png)

     - After
     ![Screenshot 2022-05-21 130517](https://user-images.githubusercontent.com/79241754/169638467-2a9a2c12-3376-40ed-a07d-b829cb141efe.png)

2. Fix height content in questionnaire  `category `
   - Before
     ![Screenshot 2022-05-21 130613](https://user-images.githubusercontent.com/79241754/169638488-035d2ebc-f370-4889-b81f-663ab8f48ae4.png)

     - After
     ![ezgif-1-f0c2ae27bb](https://user-images.githubusercontent.com/79241754/169638495-34290a17-ced1-4298-8275-85c0b0eaf3bd.gif)




## Evidence
title: refactor (questionnaire): fix height content in questionnaire for responsive
project: Desa Digital
participants: @doohanas @yoslie @Ibwedagama @agunghide 