### PR TITLE
feat (competition-page): add about section

### DIFF
--- a/pages/competition.vue
+++ b/pages/competition.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
     <CompetitionBanner @onClickCTA="showModal" />
+    <CompetitionAbout />
     <ContactUs />
     <JoinDedi :show="modalOpen" @closeModal="closeModal" />
   </div>


### PR DESCRIPTION
## Changes

- Add `about ` section in `competition` page

## Preview

1. Add `about` section in `competition` page
![update-page](https://user-images.githubusercontent.com/79241754/170038061-1875a407-b653-4953-ab88-22329cb43b31.gif)

## Evidence
title: feat (competition-page): add about section
project: Desa Digital
participants: @doohanas @naufalihsank @yoslie @maulanayuseph 