### PR TITLE
refactor (contact-us): Replace the link for the hotline number in the contact-us section

### DIFF
--- a/components/ContactUs/index.vue
+++ b/components/ContactUs/index.vue
@@ -27,7 +27,7 @@
 export default {
   methods: {
     onClickCTA () {
-      window.open('https://api.whatsapp.com/send?phone=6281312848205', '_blank')
+      window.open('https://bit.ly/HotlineSayembaraDeDi2022', '_blank')
     }
   }
 }


### PR DESCRIPTION
## Changes

- Replace the link for the hotline number in the `contact-us` section

## Preview

1. Replace the link for the hotline number in the `contact-us` section

https://user-images.githubusercontent.com/79241754/172525596-95ff6128-3ea3-47ac-836e-5300bb433764.mp4

## Evidence
title: refactor (contact-us): Replace the link for the hotline number in the contact-us section
project: Desa Digital
participants: @doohanas @maruf12 @agunghide