### PR TITLE
hotfix (village-partner): add max-width and fix text color

### DIFF
--- a/components/VillagePartner/index.vue
+++ b/components/VillagePartner/index.vue
@@ -103,7 +103,7 @@ export default {
   }
 
   &__subheading {
-    @apply text-sm text-gray-700 text-center max-w-[1000px] sm:leading-[23px];
+    @apply text-sm text-blue-gray-700 text-center max-w-[1000px] sm:leading-[23px];
   }
 
   &__switch {

--- a/components/VillagePartner/index.vue
+++ b/components/VillagePartner/index.vue
@@ -103,7 +103,7 @@ export default {
   }
 
   &__subheading {
-    @apply text-sm text-gray-700 text-center sm:leading-[23px];
+    @apply text-sm text-gray-700 text-center max-w-[1000px] sm:leading-[23px];
   }
 
   &__switch {


### PR DESCRIPTION
## Task

1. [Change](https://airtable.com/appdN4AdnU8FNs94M/tblH4guPTd65ntqNq/viwWvQmeD8YN2sEgY/recNvI1f5ndkmzp1p?blocks=hide) the text color for description text
2. [Add](https://airtable.com/appdN4AdnU8FNs94M/tblH4guPTd65ntqNq/viwWvQmeD8YN2sEgY/rec81Ay5kP142525H?blocks=hide) max-width for description text

## Changes

- Add max-width for subtitle content
- Change text color for subtitle content

## Preview

1. Add max-width and fix text color

- Before
![image](https://user-images.githubusercontent.com/79241754/174016507-37cd0bfd-9acc-4e28-8b47-9a0013612bae.png)

- After
![image](https://user-images.githubusercontent.com/79241754/174015634-a9cede25-3927-467e-9f9a-a7b1c1c05b5a.png)


## Evidence
title: hotfix (village-partner): add max-width and fix text color
project: Desa Digital
participants: @doohanas @agunghide @maulanayuseph @Ibwedagama @yoslie 