### PR TITLE
style (join-info): change text color in the subheading

### DIFF
--- a/components/JoinInfo/index.vue
+++ b/components/JoinInfo/index.vue
@@ -107,7 +107,7 @@ export default {
   }
 
   &__subheading {
-    @apply text-sm text-gray-700 text-center mt-6 sm:(leading-[23px] mt-5);
+    @apply text-sm text-blue-gray-600 text-center mt-6 sm:(leading-[23px] mt-5);
   }
 
   &__switch {


### PR DESCRIPTION
## Task

1. [Change](https://airtable.com/appdN4AdnU8FNs94M/tblH4guPTd65ntqNq/viwWvQmeD8YN2sEgY/recgU4NnI16OxXdQN?blocks=hide) the text color 

## Changes

- change text color in the subheading

## Preview

- Before
  
![image](https://user-images.githubusercontent.com/79241754/174035207-73460ad1-4426-43d0-9a09-618ed088f641.png)

- After

![image](https://user-images.githubusercontent.com/79241754/174035244-ef7d0be1-8297-496f-bfdd-6a9fb62a35e8.png)

## Evidence
title: style (join-info): change text color in the subheading
project: Desa Digital
participants: @doohanas @yoslie 