### PR TITLE
update (questionnaire): add hypen to allow validation and update error message

### DIFF
--- a/components/Questionnaire/Confirmation/index.vue
+++ b/components/Questionnaire/Confirmation/index.vue
@@ -341,9 +341,9 @@ export default {
       }
     },
     'params.nama' () {
-      const nameValidation = /(?=.*[^A-Za-z0-9.,_!@$&*?\s])/g
+      const nameValidation = /(?=.*[^A-Za-z0-9-.,_!@$&*?\s])/g
       if (nameValidation.test(this.params.nama)) {
-        this.errors.name = 'Format isian tidak valid. Karakter yang diperbolehkan (.,_!@$&*?)'
+        this.errors.name = 'Format isian tidak valid. Karakter yang diperbolehkan (.,_-!@$&*?)'
       } else if (this.params.nama.length < 3) {
         this.errors.name = 'Isian nama minimal 3 karakter.'
       } else {
@@ -351,7 +351,7 @@ export default {
       }
     },
     'params.posisi' () {
-      const roleValidation = /(?=.*[^A-Za-z0-9.,_!@$&*?\s])/g
+      const roleValidation = /(?=.*[^A-Za-z0-9-.,_!@$&*?\s])/g
       if (roleValidation.test(this.params.posisi)) {
         this.errors.position = 'Format isian tidak valid. Karakter yang diperbolehkan (.,_!@$&*?)'
       } else if (this.params.posisi.length < 1) {

--- a/components/Questionnaire/Confirmation/index.vue
+++ b/components/Questionnaire/Confirmation/index.vue
@@ -343,7 +343,7 @@ export default {
     'params.nama' () {
       const nameValidation = /(?=.*[^A-Za-z0-9-.,_!@$&*?\s])/g
       if (nameValidation.test(this.params.nama)) {
-        this.errors.name = 'Format isian tidak valid. Karakter yang diperbolehkan (.,_-!@$&*?)'
+        this.errors.name = 'Karakter yang diperbolehkan (-.,_!@$&*?)'
       } else if (this.params.nama.length < 3) {
         this.errors.name = 'Isian nama minimal 3 karakter.'
       } else {
@@ -353,7 +353,7 @@ export default {
     'params.posisi' () {
       const roleValidation = /(?=.*[^A-Za-z0-9-.,_!@$&*?\s])/g
       if (roleValidation.test(this.params.posisi)) {
-        this.errors.position = 'Format isian tidak valid. Karakter yang diperbolehkan (.,_!@$&*?)'
+        this.errors.position = 'Karakter yang diperbolehkan (-.,_!@$&*?)'
       } else if (this.params.posisi.length < 1) {
         this.errors.position = 'Isian jabatan wajib diisi.'
       } else {

--- a/components/Questionnaire/One/index.vue
+++ b/components/Questionnaire/One/index.vue
@@ -550,7 +550,7 @@ export default {
       }
     },
     'fasilitas_desa.jaringan_telepon.operator' () {
-      const telephoneValidation = /(?=.*[^A-Za-z0-9.,_!@$&*?\s])/g
+      const telephoneValidation = /(?=.*[^A-Za-z0-9-.,_!@$&*?\s])/g
       if (telephoneValidation.test(this.fasilitas_desa.jaringan_telepon.operator)) {
         this.showErrorMsg = true
         this.errors.telephone = 'Format isian tidak valid. Karakter yang diperbolehkan (.,_!@$&*?)'
@@ -582,7 +582,7 @@ export default {
       }
     },
     'fasilitas_desa.jaringan_internet.website' () {
-      const internetValidation = /(?=.*[^A-Za-z0-9.,_!@$&*?\s])/g
+      const internetValidation = /(?=.*[^A-Za-z0-9-.,_!@$&*?\s])/g
       if (internetValidation.test(this.fasilitas_desa.jaringan_internet.website)) {
         this.showInternetErrorMsg = true
         this.errors.internet = 'Format isian tidak valid. Karakter yang diperbolehkan (.,_!@$&*?)'

--- a/components/Questionnaire/One/index.vue
+++ b/components/Questionnaire/One/index.vue
@@ -553,7 +553,7 @@ export default {
       const telephoneValidation = /(?=.*[^A-Za-z0-9-.,_!@$&*?\s])/g
       if (telephoneValidation.test(this.fasilitas_desa.jaringan_telepon.operator)) {
         this.showErrorMsg = true
-        this.errors.telephone = 'Format isian tidak valid. Karakter yang diperbolehkan (.,_!@$&*?)'
+        this.errors.telephone = 'Karakter yang diperbolehkan (-.,_!@$&*?)'
       } else {
         this.showErrorMsg = false
         this.errors.telephone = ''
@@ -585,7 +585,7 @@ export default {
       const internetValidation = /(?=.*[^A-Za-z0-9-.,_!@$&*?\s])/g
       if (internetValidation.test(this.fasilitas_desa.jaringan_internet.website)) {
         this.showInternetErrorMsg = true
-        this.errors.internet = 'Format isian tidak valid. Karakter yang diperbolehkan (.,_!@$&*?)'
+        this.errors.internet = 'Karakter yang diperbolehkan (-.,_!@$&*?)'
       } else {
         this.showInternetErrorMsg = false
         this.errors.internet = ''

--- a/components/Questionnaire/Three/index.vue
+++ b/components/Questionnaire/Three/index.vue
@@ -715,7 +715,7 @@ export default {
       }
     },
     'properties.tentang_bumdes.bumdes.bumdes' () {
-      const bumdesValidation = /(?=.*[^A-Za-z0-9.,_!@$&*?\s])/g
+      const bumdesValidation = /(?=.*[^A-Za-z0-9-.,_!@$&*?\s])/g
       if (bumdesValidation.test(this.properties.tentang_bumdes.bumdes.bumdes)) {
         this.showBumdesErrorMsg = true
         this.errors.bumdes = 'Format isian tidak valid. Karakter yang diperbolehkan (.,_!@$&*?)'
@@ -725,7 +725,7 @@ export default {
       }
     },
     'properties.tentang_bumdes.komoditas.data' () {
-      const comodityValidation = /(?=.*[^A-Za-z0-9.,_!@$&*?\s])/g
+      const comodityValidation = /(?=.*[^A-Za-z0-9-.,_!@$&*?\s])/g
       if (comodityValidation.test(this.properties.tentang_bumdes.komoditas.data)) {
         this.showComodityErrorMsg = true
         this.errors.comodity = 'Format isian komoditas tidak valid. Karakter yang diperbolehkan (.,_!@$&*?)'
@@ -735,7 +735,7 @@ export default {
       }
     },
     'properties.tentang_bumdes.ecommerce.ecommerce_lainnya' () {
-      const ecommerceValidation = /(?=.*[^A-Za-z0-9.,_!@$&*?\s])/g
+      const ecommerceValidation = /(?=.*[^A-Za-z0-9-.,_!@$&*?\s])/g
       if (ecommerceValidation.test(this.properties.tentang_bumdes.ecommerce.ecommerce_lainnya)) {
         this.showEcommerceErrorMsg = true
         this.errors.ecommerce = 'Format isian tidak valid. Karakter yang diperbolehkan (.,_!@$&*?)'
@@ -745,7 +745,7 @@ export default {
       }
     },
     'properties.potensi_desa.potensi_lainnya' () {
-      const otherPotencyValidation = /(?=.*[^A-Za-z0-9.,_!@$&*?\s])/g
+      const otherPotencyValidation = /(?=.*[^A-Za-z0-9-.,_!@$&*?\s])/g
       if (otherPotencyValidation.test(this.properties.potensi_desa.potensi_lainnya)) {
         this.showOtherPotencyErrorMsg = true
         this.errors.otherPotency = 'Format isian tidak valid. Karakter yang diperbolehkan (.,_!@$&*?)'
@@ -755,7 +755,7 @@ export default {
       }
     },
     'properties.potensi_desa.potensi_dapat_dikembangkan' () {
-      const PotencyValidation = /(?=.*[^A-Za-z0-9.,_!@$&*?\s])/g
+      const PotencyValidation = /(?=.*[^A-Za-z0-9-.,_!@$&*?\s])/g
       if (PotencyValidation.test(this.properties.potensi_desa.potensi_dapat_dikembangkan)) {
         this.showPotencyErrorMsg = true
         this.errors.potency = 'Format isian potensi tidak valid. Karakter yang diperbolehkan (.,_!@$&*?)'

--- a/components/Questionnaire/Three/index.vue
+++ b/components/Questionnaire/Three/index.vue
@@ -718,7 +718,7 @@ export default {
       const bumdesValidation = /(?=.*[^A-Za-z0-9-.,_!@$&*?\s])/g
       if (bumdesValidation.test(this.properties.tentang_bumdes.bumdes.bumdes)) {
         this.showBumdesErrorMsg = true
-        this.errors.bumdes = 'Format isian tidak valid. Karakter yang diperbolehkan (.,_!@$&*?)'
+        this.errors.bumdes = 'Karakter yang diperbolehkan (-.,_!@$&*?)'
       } else {
         this.showBumdesErrorMsg = false
         this.errors.bumdes = ''
@@ -728,7 +728,7 @@ export default {
       const comodityValidation = /(?=.*[^A-Za-z0-9-.,_!@$&*?\s])/g
       if (comodityValidation.test(this.properties.tentang_bumdes.komoditas.data)) {
         this.showComodityErrorMsg = true
-        this.errors.comodity = 'Format isian komoditas tidak valid. Karakter yang diperbolehkan (.,_!@$&*?)'
+        this.errors.comodity = 'Karakter yang diperbolehkan (-.,_!@$&*?)'
       } else {
         this.showComodityErrorMsg = false
         this.errors.comodity = ''
@@ -738,7 +738,7 @@ export default {
       const ecommerceValidation = /(?=.*[^A-Za-z0-9-.,_!@$&*?\s])/g
       if (ecommerceValidation.test(this.properties.tentang_bumdes.ecommerce.ecommerce_lainnya)) {
         this.showEcommerceErrorMsg = true
-        this.errors.ecommerce = 'Format isian tidak valid. Karakter yang diperbolehkan (.,_!@$&*?)'
+        this.errors.ecommerce = 'Karakter yang diperbolehkan (-.,_!@$&*?)'
       } else {
         this.showEcommerceErrorMsg = false
         this.errors.ecommerce = ''
@@ -748,7 +748,7 @@ export default {
       const otherPotencyValidation = /(?=.*[^A-Za-z0-9-.,_!@$&*?\s])/g
       if (otherPotencyValidation.test(this.properties.potensi_desa.potensi_lainnya)) {
         this.showOtherPotencyErrorMsg = true
-        this.errors.otherPotency = 'Format isian tidak valid. Karakter yang diperbolehkan (.,_!@$&*?)'
+        this.errors.otherPotency = 'Karakter yang diperbolehkan (-.,_!@$&*?)'
       } else {
         this.showOtherPotencyErrorMsg = false
         this.errors.otherPotency = ''
@@ -758,7 +758,7 @@ export default {
       const PotencyValidation = /(?=.*[^A-Za-z0-9-.,_!@$&*?\s])/g
       if (PotencyValidation.test(this.properties.potensi_desa.potensi_dapat_dikembangkan)) {
         this.showPotencyErrorMsg = true
-        this.errors.potency = 'Format isian potensi tidak valid. Karakter yang diperbolehkan (.,_!@$&*?)'
+        this.errors.potency = 'Karakter yang diperbolehkan (-.,_!@$&*?)'
       } else {
         this.showPotencyErrorMsg = false
         this.errors.potency = ''

--- a/components/Questionnaire/Two/index.vue
+++ b/components/Questionnaire/Two/index.vue
@@ -306,7 +306,7 @@ export default {
       }
     },
     'literasi_digital.pelatihan.pelatihan' () {
-      const trainingValidation = /(?=.*[^A-Za-z0-9.,_!@$&*?\s])/g
+      const trainingValidation = /(?=.*[^A-Za-z0-9-.,_!@$&*?\s])/g
       if (trainingValidation.test(this.literasi_digital.pelatihan.pelatihan)) {
         this.showTrainingErrorMsg = true
         this.errors.training = 'Format isian tidak valid. Karakter yang diperbolehkan (.,_!@$&*?)'

--- a/components/Questionnaire/Two/index.vue
+++ b/components/Questionnaire/Two/index.vue
@@ -309,7 +309,7 @@ export default {
       const trainingValidation = /(?=.*[^A-Za-z0-9-.,_!@$&*?\s])/g
       if (trainingValidation.test(this.literasi_digital.pelatihan.pelatihan)) {
         this.showTrainingErrorMsg = true
-        this.errors.training = 'Format isian tidak valid. Karakter yang diperbolehkan (.,_!@$&*?)'
+        this.errors.training = 'Karakter yang diperbolehkan (-.,_!@$&*?)'
       } else {
         this.showTrainingErrorMsg = false
         this.errors.training = ''


### PR DESCRIPTION
## Changes

- Update regex in questionnaire: Add hyphen to allow validation in `text` and `textarea` input
- Update error message text in the questionnaire

## Preview

1. Update regex in questionnaire: Add hyphen to allow validation in `text` input
   - Before
     ![image](https://user-images.githubusercontent.com/79241754/176356346-ef30cee4-a6d3-4c97-81c0-7cbbe689cfe6.png)
 
   - After
     ![image](https://user-images.githubusercontent.com/79241754/176356490-f130b1fd-6861-4da6-a39b-5e67be9d4a8a.png)

2. Update regex in questionnaire: Add hyphen to allow validation in `textarea` input
   - Before
     ![image](https://user-images.githubusercontent.com/79241754/176356884-5d73e94e-f20b-4159-96d1-a07522d0d13c.png) 

   - After
     ![image](https://user-images.githubusercontent.com/79241754/176356942-7c18dbd8-31c6-434b-9941-53d14b74bca8.png)

3. Update error message text in the questionnaire
   - Before
     ![image](https://user-images.githubusercontent.com/79241754/176357041-21e9a6af-4996-4f71-8c13-45cf79e68e82.png) 

   - After
     ![image](https://user-images.githubusercontent.com/79241754/176357220-2a658d33-19a5-4d45-aca6-68ab41ababde.png)

## Evidence
title: update (questionnaire): add hyphen to allow validation and update the error message
project: Desa Digital
participants: @doohanas @yoslie @Ibwedagama @agunghide 