### PR TITLE
style (tab-feature): add max-width full in container tab feature

### DIFF
--- a/components/JoinInfo/index.vue
+++ b/components/JoinInfo/index.vue
@@ -109,11 +109,11 @@ export default {
   }
 
   &__switch {
-    @apply h-[60px] max-w-[376px] sm:w-[376px] rounded-[48px] bg-[#EBEEF3] my-8 flex;
+    @apply h-[60px] max-w-full sm:max-w-[376px] rounded-[48px] bg-[#EBEEF3] my-8 flex;
 
     &--active {
       box-shadow: 0px 4px 12px rgba(0, 27, 61, 0.08);
-      @apply bg-white rounded-[48px] max-w-[184px] sm:w-[184px] h-[52px] m-1 flex items-center justify-center transition-all delay-75;
+      @apply bg-white rounded-[48px] w-[184px] sm:max-w-[184px] h-[52px] m-1 flex items-center justify-center transition-all delay-75;
 
       &-text {
         @apply px-5 py-4 text-blue-gray-800 text-[16px] leading-[19px] font-bold text-center;
@@ -121,7 +121,7 @@ export default {
     }
 
     &--non-active {
-      @apply rounded-[48px] max-w-[184px] sm:w-[184px] h-[52px] m-1 flex items-center justify-center cursor-pointer;
+      @apply rounded-[48px] w-[184px] sm:max-w-[184px] h-[52px] m-1 flex items-center justify-center cursor-pointer;
 
       &-text {
         @apply px-5 py-4 text-blue-gray-400 text-[16px] leading-[19px] text-center;

--- a/components/VillagePartner/index.vue
+++ b/components/VillagePartner/index.vue
@@ -143,11 +143,11 @@ export default {
   }
 
   &__switch {
-    @apply h-[60px] max-w-[376px] sm:w-[376px] rounded-[48px] bg-[#EBEEF3] my-8 flex;
+    @apply h-[60px] max-w-full sm:max-w-[376px] rounded-[48px] bg-[#EBEEF3] my-8 flex;
 
     &--active {
       box-shadow: 0px 4px 12px rgba(0, 27, 61, 0.08);
-      @apply bg-white rounded-[48px] max-w-[184px] sm:w-[184px] h-[52px] m-1 flex items-center justify-center transition-all delay-75;
+      @apply bg-white rounded-[48px] w-[184px] sm:max-w-[184px] h-[52px] m-1 flex items-center justify-center transition-all delay-75;
 
       &-text {
         @apply px-5 py-4 text-blue-gray-800 text-[16px] leading-[19px] font-bold text-center;
@@ -155,7 +155,7 @@ export default {
     }
 
     &--non-active {
-      @apply rounded-[48px] max-w-[184px] sm:w-[184px] h-[52px] m-1 flex items-center justify-center cursor-pointer;
+      @apply rounded-[48px] w-[184px] sm:max-w-[184px] h-[52px] m-1 flex items-center justify-center cursor-pointer;
 
       &-text {
         @apply px-5 py-4 text-blue-gray-400 text-[16px] leading-[19px] text-center;


### PR DESCRIPTION
## Task

1. Difference style of the [tabular](https://airtable.com/appdN4AdnU8FNs94M/tblH4guPTd65ntqNq/viwWvQmeD8YN2sEgY/reciUpFDXICpAO1Zo?blocks=hide)

## Changes

- style (tab-feature): add max-width full in container tab feature

## Preview

1. Add max-width full in container tab feature (Mobile)

   - Before
      
     - village-partner section
       
        ![image](https://user-images.githubusercontent.com/79241754/177248956-b5675fcb-da2b-4991-877c-68c3f9d005b3.png)

     - join-info section

       ![image](https://user-images.githubusercontent.com/79241754/177248975-3ce5cc8c-4528-4bd4-a880-23481ee5877e.png)

   - After

     - village-partner section
       
        ![image](https://user-images.githubusercontent.com/79241754/177249090-1934c2c4-3ac2-4899-ae14-6770027a6ed0.png)

     - join-info section

      ![image](https://user-images.githubusercontent.com/79241754/177249090-1934c2c4-3ac2-4899-ae14-6770027a6ed0.png)

## Evidence
title: style (tab-feature): add max-width full in container tab feature
project: Desa Digital
participants: @doohanas @agunghide @Ibwedagama 