### PR TITLE
style (about-dedi): change width and space Breadcrumbs in pagination

### DIFF
--- a/components/Card/Achievement/index.vue
+++ b/components/Card/Achievement/index.vue
@@ -249,7 +249,7 @@ export default {
   }
 
   .achievement-nav {
-    @apply w-full h-full flex flex-row pt-6 gap-8 justify-center;
+    @apply w-full h-full flex flex-row pt-6 gap-8 justify-between mx-4 sm:mx-0;
 
     .button-left, .button-right {
       @apply w-[42px] h-[42px] bg-green-700 text-white font-light rounded-full

--- a/components/Card/Achievement/index.vue
+++ b/components/Card/Achievement/index.vue
@@ -264,7 +264,7 @@ export default {
       @apply relative flex flex-row items-center justify-center !important;
 
       &-bullet {
-        @apply w-3 h-3 bg-gray-300 border-0 transition-all duration-300 !important;
+        @apply w-3 h-3 bg-gray-300 border-0 transition-all duration-300 ml-0 mr-3 !important;
 
         &-active {
           @apply w-8 h-3 bg-green-600 border-0 rounded-md !important;

--- a/components/DevelopmentStage/index.vue
+++ b/components/DevelopmentStage/index.vue
@@ -257,7 +257,7 @@ export default {
     }
 
     &-pagination-dot {
-      @apply float-left mr-[20px] w-3 h-3 rounded-full bg-gray-300 transition-all duration-300 ease-in-out;
+      @apply float-left mr-[12px] w-3 h-3 rounded-full bg-gray-300 transition-all duration-300 ease-in-out;
 
       &--active {
         @apply w-[44px] cursor-auto bg-green-600;

--- a/components/DevelopmentStage/index.vue
+++ b/components/DevelopmentStage/index.vue
@@ -260,7 +260,7 @@ export default {
       @apply float-left mr-[12px] w-3 h-3 rounded-full bg-gray-300 transition-all duration-300 ease-in-out;
 
       &--active {
-        @apply w-[44px] cursor-auto bg-green-600;
+        @apply w-[32px] cursor-auto bg-green-600;
       }
     }
 


### PR DESCRIPTION
## Task

1. [T75 ](https://airtable.com/appdN4AdnU8FNs94M/tblH4guPTd65ntqNq/viwWvQmeD8YN2sEgY/rec7Sc8n49BnYKVZV?blocks=hide) - Lebar dan Jarak Breadcrumbs card penghargaan dan card Tahapan Pengembangan pada tampilan mobile - FE

## Changes

- Change width and space Breadcrumbs in pagination

## Preview

- Before 
![image](https://user-images.githubusercontent.com/79241754/177460956-a0e40cfc-5ebd-4f41-80a7-fa98b12a263f.png)

- After
![image](https://user-images.githubusercontent.com/79241754/177460969-2eff821d-5e59-4495-a4cf-c777cdb603df.png)


## Evidence
title: style (about-dedi): change width and space Breadcrumbs in pagination
project: Desa Digital
participants: @doohanas @yoslie @agunghide @Ibwedagama @maulanayuseph @naufalihsank 